### PR TITLE
Add firebase firestore implementation

### DIFF
--- a/src/app/shared/data-access/entity.service.interface.ts
+++ b/src/app/shared/data-access/entity.service.interface.ts
@@ -4,8 +4,8 @@ import { Observable } from 'rxjs';
 export interface IEntityService<T extends Entity> {
     get(id: string): Promise<T>;
     getAsync(id: string): Observable<T>;
-    add(entity: T): Promise<void>;
-    update(updatedEntity: T): Promise<void>;
+    add(entity: T, id?: string): Promise<T>;
+    update(updatedEntity: T): Promise<T>;
     delete(id: string): Promise<void>;
 }
 
@@ -18,7 +18,9 @@ export abstract class EntityService<T extends Entity> implements IEntityService<
 
     abstract get(id: string): Promise<T>;
     abstract getAsync(id: string): Observable<T>;
-    abstract add(entity: T): Promise<void>;
-    abstract update(updatedEntity: T): Promise<void>;
+    abstract list(): Promise<T[]>;
+    abstract listAsync(): Observable<T[]>;
+    abstract add(entity: T, id?: string): Promise<T>;
+    abstract update(updatedEntity: T): Promise<T>;
     abstract delete(id: string): Promise<void>;
 }

--- a/src/app/shared/data-access/firebase/firebase.dal.module.ts
+++ b/src/app/shared/data-access/firebase/firebase.dal.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { AngularFirestoreModule } from '@angular/fire/firestore';
+
+@NgModule({
+    imports: [AngularFirestoreModule]
+})
+export class FirebaseDALModule {}

--- a/src/app/shared/data-access/firebase/services/firebase-entity.service.ts
+++ b/src/app/shared/data-access/firebase/services/firebase-entity.service.ts
@@ -1,0 +1,130 @@
+import { Injectable } from '@angular/core';
+import { EntityService } from '../../entity.service.interface';
+import { Entity } from '../../entity.interface';
+import { AngularFirestore, AngularFirestoreCollection } from '@angular/fire/firestore';
+import { take, map } from 'rxjs/operators';
+import { Observable } from 'rxjs/internal/Observable';
+
+export abstract class FirebaseEntityService<T extends Entity> extends EntityService<T> {
+    protected collection: AngularFirestoreCollection<T>;
+
+    constructor(name: string, private afs: AngularFirestore) {
+        super(name);
+        this.collection = this.afs.collection(name);
+    }
+
+    get(id: string): Promise<T> {
+        return this.collection
+            .doc<T>(id)
+            .snapshotChanges()
+            .pipe(
+                map(doc => {
+                    if (doc.payload.exists) {
+                        const data = doc.payload.data();
+                        const payloadId = doc.payload.id;
+                        return { id: payloadId, ...data };
+                    }
+                }),
+                take(1)
+            )
+            .toPromise();
+    }
+
+    getAsync(id: string): Observable<T> {
+        return this.collection
+            .doc<T>(id)
+            .snapshotChanges()
+            .pipe(
+                map(doc => {
+                    if (doc.payload.exists) {
+                        const data = doc.payload.data();
+                        const payloadId = doc.payload.id;
+                        return { id: payloadId, ...data };
+                    }
+                })
+            );
+    }
+
+    list(): Promise<T[]> {
+        return this.collection
+            .snapshotChanges()
+            .pipe(
+                map(changes => {
+                    return changes.map(a => {
+                        const data = a.payload.doc.data() as T;
+                        data.id = a.payload.doc.id;
+                        return data;
+                    });
+                }),
+                take(1)
+            )
+            .toPromise();
+    }
+
+    listAsync(): Observable<T[]> {
+        return this.collection.snapshotChanges().pipe(
+            map(changes => {
+                return changes.map(a => {
+                    const data = a.payload.doc.data() as T;
+                    data.id = a.payload.doc.id;
+                    return data;
+                });
+            })
+        );
+    }
+
+    /**
+     * Add a new entity to the collection
+     * @param entity Entity to add
+     * @param id Optional - Use ID to add a specific entity with ID
+     */
+    add(entity: T, id?: string): Promise<T> {
+        const promise = new Promise<T>((resolve, reject) => {
+            if (!!id) {
+                this.collection
+                    .doc(id)
+                    .set(firebaseSerialize(entity))
+                    .then(ref => {
+                        resolve(entity);
+                    });
+            } else {
+                this.collection.add(firebaseSerialize(entity)).then(ref => {
+                    const newentity = {
+                        id: ref.id,
+                        ...entity
+                    };
+                    resolve(newentity);
+                });
+            }
+        });
+        return promise;
+    }
+
+    update(updatedEntity: T): Promise<T> {
+        const promise = new Promise<T>((resolve, reject) => {
+            const docRef = this.collection
+                .doc<T>(updatedEntity.id as string)
+                .set(firebaseSerialize(updatedEntity))
+                .then(() => {
+                    resolve({
+                        ...updatedEntity
+                    });
+                });
+        });
+        return promise;
+    }
+
+    delete(id: string): Promise<void> {
+        const promise = new Promise<void>((resolve, reject) => {
+            const docRef = this.collection.doc<T>(id);
+            docRef.delete().then(() => {
+                resolve();
+            });
+        });
+        return promise;
+    }
+}
+
+export function firebaseSerialize<T>(object: T) {
+    return JSON.parse(JSON.stringify(object));
+}


### PR DESCRIPTION
Add firebase firestore implementation.

It is an abstract class to allow further model services to extend it and set their own collection paths.